### PR TITLE
Update channel.dart

### DIFF
--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -49,7 +49,7 @@ class PhoenixChannel {
   }
 
   /// Parameters passed to the backend at join time.
-  final Map<String, String> parameters;
+  final Map<String, dynamic> parameters;
 
   /// The [PhoenixSocket] through which this channel is established.
   final PhoenixSocket socket;


### PR DESCRIPTION
Sorry mate, my mistake! we need to update this 'parameters' to avoid this error in 0.4.7:

I/flutter (10251): Exception: type '_InternalLinkedHashMap<String, dynamic>' is not a subtype of type 'Map<String, String>'
I/flutter (10251): #0 PhoenixSocket.addChannel (package:phoenix_socket/src/socket.dart:335:21)