### PR TITLE
Fix possible infinite loop on push reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.4.10]
+
+- Make sure Push instances trigger only one event, and only once (#18)
+
 ## [0.4.9]
 
 - Bugfix (#15)

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -199,7 +199,6 @@ class PhoenixChannel {
       final onClose = (PushResponse reply) {
         _onClose(reply);
         close();
-        leavePush.trigger(PushResponse(status: 'ok'));
       };
       leavePush
         ..onReply('ok', onClose)

--- a/lib/src/push.dart
+++ b/lib/src/push.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
+import 'package:equatable/equatable.dart';
 import 'package:logging/logging.dart';
 import 'package:quiver/collection.dart';
-import 'package:equatable/equatable.dart';
 
 import 'channel.dart';
 import 'events.dart';
@@ -239,16 +239,19 @@ class Push {
         _responseCompleter.complete(response);
       }
     }
+
     _logger.finer(() {
       if (_receivers[response.status].isNotEmpty) {
         return 'Triggering ${_receivers[response.status].length} callbacks';
       }
       return 'Not triggering any callbacks';
     });
-    for (final cb in _receivers[response.status]) {
+
+    final receivers = _receivers[response.status].toList();
+    clearWaiters();
+    for (final cb in receivers) {
       cb(response);
     }
-    clearWaiters();
   }
 
   /// Dispose the set of waiters and future associated with this push.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   PhoenixSocket provides a feature-complete implementation
   of Phoenix Sockets, using a single API based on StreamChannels
   compatible with any deployment of Flutter.
-version: 0.4.9
+version: 0.4.10
 repository: https://www.github.com/matehat/phoenix-socket-dart
 homepage: https://www.github.com/matehat/phoenix-socket-dart
 


### PR DESCRIPTION
- Fix a bug in the channel leave push handler
- Ensure a push reply handler cannot trigger handlers again. Now all handlers are unmounted before triggering them.

Addresses #18 

/cc @hworld