### PR TITLE
Fix occasional issue when reconnecting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.5.1.]
+
+- Fix re-connection issue
+
 ## [0.5.0]
 
 - Add sound null safety

--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -208,7 +208,7 @@ class PhoenixSocket {
     try {
       _socketState = SocketState.connected;
       _logger.finest('Waiting for initial heartbeat roundtrip');
-      if (await _sendHeartbeat()) {
+      if (await _sendHeartbeat(ignorePreviousHeartbeat: true)) {
         _stateStreamController.add(PhoenixSocketOpenEvent());
         _logger.info('Socket open');
         completer.complete(this);
@@ -413,10 +413,10 @@ class PhoenixSocket {
     _heartbeatTimeout = null;
   }
 
-  Future<bool> _sendHeartbeat() async {
+  Future<bool> _sendHeartbeat({bool ignorePreviousHeartbeat = false}) async {
     if (!isConnected) return false;
 
-    if (_nextHeartbeatRef != null) {
+    if (_nextHeartbeatRef != null && !ignorePreviousHeartbeat) {
       _nextHeartbeatRef = null;
       if (_ws != null) {
         unawaited(_ws!.sink.close(normalClosure, 'heartbeat timeout'));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   PhoenixSocket provides a feature-complete implementation
   of Phoenix Sockets, using a single API based on StreamChannels
   compatible with any deployment of Flutter.
-version: 0.5.0
+version: 0.5.1
 repository: https://www.github.com/matehat/phoenix-socket-dart
 homepage: https://www.github.com/matehat/phoenix-socket-dart
 


### PR DESCRIPTION
If a heartbeat was still pending when a full reconnection was attempted, PhoenixSocket would interpret that as a timed out heartbeat immediately and consider the connection failed.

This PR fixes this by not considering previous heartbeat attempts when re-starting a new connection.