### PR TITLE
relax rxdart dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   meta: ^1.2.4
   pedantic: ^1.9.2
   quiver: ^3.0.0
-  rxdart: ^0.26.0
+  rxdart: '>=0.26.0 <0.28.0'
   web_socket_channel: ^2.0.0
   collection: ^1.15.0
 


### PR DESCRIPTION
allow using rxdart ^0.27.0 without dependency overrides.

This rxdart release has breaking changes, but these do not affect phoenix-socket-dart.