### PR TITLE
Fix: correct usage of channels map

### DIFF
--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -355,7 +355,7 @@ class PhoenixSocket {
         timeout: timeout ?? defaultTimeout,
       );
 
-      channels[channel.reference] = channel;
+      channels[channel.topic] = channel;
       _logger.finer(() => 'Adding channel ${channel!.topic}');
     } else {
       _logger.finer(() => 'Reusing existing channel ${channel!.topic}');
@@ -370,7 +370,7 @@ class PhoenixSocket {
   /// leaving the channel.
   void removeChannel(PhoenixChannel channel) {
     _logger.finer(() => 'Removing channel ${channel.topic}');
-    if (channels.remove(channel.reference) is PhoenixChannel) {
+    if (channels.remove(channel.topic) is PhoenixChannel) {
       _topicStreams.remove(channel.topic);
     }
   }

--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -340,12 +340,7 @@ class PhoenixSocket {
     Map<String, dynamic>? parameters,
     Duration? timeout,
   }) {
-    PhoenixChannel? channel;
-    if (channels.isNotEmpty) {
-      final foundChannels =
-          channels.entries.where((element) => element.value.topic == topic);
-      channel = foundChannels.isNotEmpty ? foundChannels.first.value : null;
-    }
+    PhoenixChannel? channel = channels[topic];
 
     if (channel == null) {
       channel = PhoenixChannel.fromSocket(


### PR DESCRIPTION
I noticed that the map channels comment says:

```
 /// [Map] of topic names to [PhoenixChannel] instances being
 /// maintained and tracked by the socket.
```

But what we see before this PR is a numerical reference to channels. This PR fixes this.

As a bonus we were able to reduce the time complexity to add new channel from O(n) to O(1)