### PR TITLE
Update pub-points badge in README.md fixes #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![ci-test](https://github.com/braverhealth/phoenix-socket-dart/actions/workflows/test.yaml/badge.svg)](https://github.com/braverhealth/phoenix-socket-dart/actions/workflows/test.yaml)
 [![pub-package](https://img.shields.io/pub/v/phoenix_socket.svg)](https://pub.dev/packages/phoenix_socket)
-[![pub-points](https://badges.bar/phoenix_socket/pub%20points)](https://pub.dev/packages/phoenix_socket/score)
+![Pub Points](https://img.shields.io/pub/points/phoenix_socket?color=blue&label=pub%20points)
 
 Dart library to interact with [Phoenix][1] [Channels][2] ([Presence][3] support is currently _experimental_) over WebSockets.
 


### PR DESCRIPTION
This PR: 
+ [x] Fixes broken `pub-points` badge in `README.md` #56 

Before: [![pub-points](https://badges.bar/phoenix_socket/pub%20points)](https://pub.dev/packages/phoenix_socket/score) 
After: ![Pub Points](https://img.shields.io/pub/points/phoenix_socket?color=blue&label=pub%20points) 