### PR TITLE
Add support for custom decoder and encoder

### DIFF
--- a/lib/src/message_serializer.dart
+++ b/lib/src/message_serializer.dart
@@ -4,21 +4,30 @@ import 'message.dart';
 
 /// Default class to serialize [Message] instances to JSON.
 class MessageSerializer {
+  late Function decoder;
+  late Function encoder;
+
   MessageSerializer._();
 
   /// Default constructor returning the singleton instance of this class.
-  factory MessageSerializer() => _instance ??= MessageSerializer._();
+  factory MessageSerializer({decoder, encoder}) {
+    MessageSerializer instance = _instance ??= MessageSerializer._();
+    instance.decoder = decoder ?? jsonDecode;
+    instance.encoder = encoder ?? jsonEncode;
+
+    return instance;
+  }
 
   static MessageSerializer? _instance;
 
   /// Yield a [Message] from some raw string arriving from a websocket.
-  Message decode(String rawData) {
-    return Message.fromJson(jsonDecode(rawData));
+  Message decode(dynamic rawData) {
+    return Message.fromJson(decoder(rawData));
   }
 
   /// Given a [Message], return the raw string that would be sent through
   /// a websocket.
   String encode(Message message) {
-    return jsonEncode(message.encode());
+    return encoder(message.encode());
   }
 }

--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -355,7 +355,7 @@ class PhoenixSocket {
         timeout: timeout ?? defaultTimeout,
       );
 
-      channels[channel.reference] = channel;
+      channels[channel.topic] = channel;
       _logger.finer(() => 'Adding channel ${channel!.topic}');
     } else {
       _logger.finer(() => 'Reusing existing channel ${channel!.topic}');
@@ -370,7 +370,7 @@ class PhoenixSocket {
   /// leaving the channel.
   void removeChannel(PhoenixChannel channel) {
     _logger.finer(() => 'Removing channel ${channel.topic}');
-    if (channels.remove(channel.reference) is PhoenixChannel) {
+    if (channels.remove(channel.topic) is PhoenixChannel) {
       _topicStreams.remove(channel.topic);
     }
   }

--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -83,7 +83,7 @@ class PhoenixSocket {
 
   final BehaviorSubject<PhoenixSocketEvent> _stateStreamController =
       BehaviorSubject();
-  final StreamController<String> _receiveStreamController =
+  final StreamController<dynamic> _receiveStreamController =
       StreamController.broadcast();
   final String _endpoint;
   final StreamController<Message> _topicMessages = StreamController();
@@ -479,12 +479,12 @@ class PhoenixSocket {
   }
 
   void _onSocketData(message) {
-    if (message is String) {
+    if (message is String || message is List<int>) {
       if (!_receiveStreamController.isClosed) {
         _receiveStreamController.add(message);
       }
     } else {
-      throw ArgumentError('Received a non-string');
+      throw ArgumentError('Received a non-string or a list of integers');
     }
   }
 

--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -340,12 +340,7 @@ class PhoenixSocket {
     Map<String, dynamic>? parameters,
     Duration? timeout,
   }) {
-    PhoenixChannel? channel;
-    if (channels.isNotEmpty) {
-      final foundChannels =
-          channels.entries.where((element) => element.value.topic == topic);
-      channel = foundChannels.isNotEmpty ? foundChannels.first.value : null;
-    }
+    PhoenixChannel? channel = channels[topic];
 
     if (channel == null) {
       channel = PhoenixChannel.fromSocket(


### PR DESCRIPTION
Adding support to add your own encoder and decoder.

**For example:**

Using BERT decoder for incoming messages
https://pub.dev/packages/bert
https://github.com/Youimmi/bert.git

```
import 'package:bert/bert.dart as bert';
import 'package:phoenix_socket/src/message_serializer.dart';

socket = PhoenixSocket(
  socketUrl,
  socketOptions: PhoenixSocketOptions(
    serializer: MessageSerializer(decoder: bert.decode),
  ),
);
```

