### PR TITLE
Add support for custom decoder and encoder

### DIFF
--- a/lib/phoenix_socket.dart
+++ b/lib/phoenix_socket.dart
@@ -22,5 +22,6 @@ export 'src/exceptions.dart';
 export 'src/message.dart';
 export 'src/presence.dart';
 export 'src/push.dart';
+export 'src/raw_socket.dart';
 export 'src/socket.dart';
 export 'src/socket_options.dart';

--- a/lib/src/message_serializer.dart
+++ b/lib/src/message_serializer.dart
@@ -4,21 +4,34 @@ import 'message.dart';
 
 /// Default class to serialize [Message] instances to JSON.
 class MessageSerializer {
+  late Function decoder;
+  late Function encoder;
+
   MessageSerializer._();
 
   /// Default constructor returning the singleton instance of this class.
-  factory MessageSerializer() => _instance ??= MessageSerializer._();
+  factory MessageSerializer({decoder, encoder}) {
+    MessageSerializer instance = _instance ??= MessageSerializer._();
+    instance.decoder = decoder ?? jsonDecode;
+    instance.encoder = encoder ?? jsonEncode;
+
+    return instance;
+  }
 
   static MessageSerializer? _instance;
 
   /// Yield a [Message] from some raw string arriving from a websocket.
-  Message decode(String rawData) {
-    return Message.fromJson(jsonDecode(rawData));
+  Message decode(dynamic rawData) {
+    if (rawData is String || rawData is List<int>) {
+      return Message.fromJson(decoder(rawData));
+    } else {
+      throw ArgumentError('Received a non-string or a non-list of integers');
+    }
   }
 
   /// Given a [Message], return the raw string that would be sent through
   /// a websocket.
   String encode(Message message) {
-    return jsonEncode(message.encode());
+    return encoder(message.encode());
   }
 }

--- a/lib/src/raw_socket.dart
+++ b/lib/src/raw_socket.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+
+import 'socket.dart';
+
+/// Main class to use when wishing to establish a persistent connection
+/// with a Phoenix backend using WebSockets.
+class PhoenixRawSocket extends PhoenixSocket {
+  final StreamController<List<int>> _receiveStreamController =
+      StreamController.broadcast();
+
+  /// Creates an instance of PhoenixRawSocket
+  ///
+  /// endpoint is the full url to which you wish to connect
+  /// e.g. `ws://localhost:4000/websocket/socket`
+  PhoenixRawSocket(super.endpoint, {super.socketOptions});
+
+  @override
+  void onSocketDataCallback(message) {
+    if (message is List<int>) {
+      if (!_receiveStreamController.isClosed) {
+        _receiveStreamController.add(message);
+      }
+    } else {
+      throw ArgumentError('Received a non-list of integers');
+    }
+  }
+}

--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -376,6 +376,19 @@ class PhoenixSocket {
     }
   }
 
+  /// Processing incoming data from the socket
+  ///
+  /// Used to define a custom message type for proper data decoding
+  onSocketDataCallback(message) {
+    if (message is String) {
+      if (!_receiveStreamController.isClosed) {
+        _receiveStreamController.add(message);
+      }
+    } else {
+      throw ArgumentError('Received a non-string');
+    }
+  }
+
   bool _shouldPipeMessage(dynamic event) {
     if (event is WebSocketChannelException) {
       return true;
@@ -484,15 +497,7 @@ class PhoenixSocket {
     }
   }
 
-  void _onSocketData(message) {
-    if (message is String) {
-      if (!_receiveStreamController.isClosed) {
-        _receiveStreamController.add(message);
-      }
-    } else {
-      throw ArgumentError('Received a non-string');
-    }
-  }
+  void _onSocketData(message) => onSocketDataCallback(message);
 
   void _onSocketError(dynamic error, dynamic stacktrace) {
     if (_socketState == SocketState.closing ||


### PR DESCRIPTION
Parent: https://github.com/braverhealth/phoenix-socket-dart/pull/59

Adding support to add your own encoder and decoder.

**For example:**

Using BERT decoder for incoming messages
https://pub.dev/packages/bert
https://github.com/Youimmi/bert.git

```
import 'package:bert/bert.dart as bert';
import 'package:phoenix_socket/src/message_serializer.dart';

socket = PhoenixRawSocket(
  socketUrl,
  socketOptions: PhoenixSocketOptions(
    serializer: MessageSerializer(decoder: bert.decode),
  ),
);
```