### PR TITLE
Export message_serializer.dart

### DIFF
--- a/lib/phoenix_socket.dart
+++ b/lib/phoenix_socket.dart
@@ -20,6 +20,7 @@ export 'src/channel.dart';
 export 'src/events.dart';
 export 'src/exceptions.dart';
 export 'src/message.dart';
+export 'src/message_serializer.dart';
 export 'src/presence.dart';
 export 'src/push.dart';
 export 'src/socket.dart';


### PR DESCRIPTION
In order to be able to implement an different instance of `MessageSerializer`, `message_serializer.dart` needs to be exported by the package in order to do so.