### PR TITLE
Refactor: Reduce reliance of the package on 3rd party dependencies

### DIFF
--- a/example/flutter_app/lib/main.dart
+++ b/example/flutter_app/lib/main.dart
@@ -129,7 +129,7 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             Text(
               '$_counter',
-              style: Theme.of(context).textTheme.headline4,
+              style: Theme.of(context).textTheme.headlineMedium,
             ),
           ],
         ),

--- a/example/reactive/client/lib/main.dart
+++ b/example/reactive/client/lib/main.dart
@@ -82,7 +82,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 return Container(
                   child: Text(
                     '$_counter',
-                    style: Theme.of(context).textTheme.headline4,
+                    style: Theme.of(context).textTheme.headlineMedium,
                   ),
                 );
               },

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:logging/logging.dart';
-import 'package:pedantic/pedantic.dart';
 
 import 'events.dart';
 import 'exceptions.dart';

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -1,19 +1,11 @@
-import 'package:equatable/equatable.dart';
-
 import 'channel.dart';
 import 'socket.dart';
 
 /// Base socket event
-abstract class PhoenixSocketEvent extends Equatable {
-  @override
-  bool get stringify => true;
-}
+abstract class PhoenixSocketEvent {}
 
 /// Open event for a [PhoenixSocket].
-class PhoenixSocketOpenEvent extends PhoenixSocketEvent {
-  @override
-  List<Object?> get props => [];
-}
+class PhoenixSocketOpenEvent extends PhoenixSocketEvent {}
 
 /// Close event for a [PhoenixSocket].
 class PhoenixSocketCloseEvent extends PhoenixSocketEvent {
@@ -30,7 +22,19 @@ class PhoenixSocketCloseEvent extends PhoenixSocketEvent {
   final int? code;
 
   @override
-  List<Object?> get props => [code, reason];
+  bool operator ==(Object other) {
+    return other is PhoenixSocketCloseEvent &&
+        other.reason == reason &&
+        other.code == code;
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, reason, code);
+
+  @override
+  String toString() {
+    return 'PhoenixSocketCloseEvent(reason: $reason, code: $code)';
+  }
 }
 
 /// Error event for a [PhoenixSocket].
@@ -42,17 +46,27 @@ class PhoenixSocketErrorEvent extends PhoenixSocketEvent {
   });
 
   /// The error that happened on the socket
-  final dynamic error;
+  final Object? error;
 
   /// The stacktrace associated with the error.
   final dynamic stacktrace;
 
   @override
-  List<Object?> get props => [error];
+  bool operator ==(Object other) {
+    return other is PhoenixSocketErrorEvent && other.error == error;
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, error);
+
+  @override
+  String toString() {
+    return 'PhoenixSocketErrorEvent(error: $error)';
+  }
 }
 
 /// Encapsulates constants used in the protocol over [PhoenixChannel].
-class PhoenixChannelEvent extends Equatable {
+class PhoenixChannelEvent {
   PhoenixChannelEvent._(this.value);
 
   /// A reply event name for a given push ref value.
@@ -120,5 +134,10 @@ class PhoenixChannelEvent extends Equatable {
       value.startsWith(__replyEventName);
 
   @override
-  List<Object> get props => [value];
+  bool operator ==(Object other) {
+    return other is PhoenixChannelEvent && other.value == value;
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, value);
 }

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -26,19 +26,16 @@ class PhoenixSocketCloseEvent extends PhoenixSocketEvent {
   final int? code;
 
   @override
-  bool operator ==(Object other) {
-    return other is PhoenixSocketCloseEvent &&
-        other.reason == reason &&
-        other.code == code;
-  }
+  bool operator ==(Object other) =>
+      other is PhoenixSocketCloseEvent &&
+      other.reason == reason &&
+      other.code == code;
 
   @override
   int get hashCode => Object.hash(runtimeType, reason, code);
 
   @override
-  String toString() {
-    return 'PhoenixSocketCloseEvent(reason: $reason, code: $code)';
-  }
+  String toString() => 'PhoenixSocketCloseEvent(reason: $reason, code: $code)';
 }
 
 /// Error event for a [PhoenixSocket].
@@ -56,17 +53,14 @@ class PhoenixSocketErrorEvent extends PhoenixSocketEvent {
   final dynamic stacktrace;
 
   @override
-  bool operator ==(Object other) {
-    return other is PhoenixSocketErrorEvent && other.error == error;
-  }
+  bool operator ==(Object other) =>
+      other is PhoenixSocketErrorEvent && other.error == error;
 
   @override
   int get hashCode => Object.hash(runtimeType, error);
 
   @override
-  String toString() {
-    return 'PhoenixSocketErrorEvent(error: $error)';
-  }
+  String toString() => 'PhoenixSocketErrorEvent(error: $error)';
 }
 
 /// Encapsulates constants used in the protocol over [PhoenixChannel].
@@ -139,9 +133,8 @@ class PhoenixChannelEvent {
       value.startsWith(__replyEventName);
 
   @override
-  bool operator ==(Object other) {
-    return other is PhoenixChannelEvent && other.value == value;
-  }
+  bool operator ==(Object other) =>
+      other is PhoenixChannelEvent && other.value == value;
 
   @override
   int get hashCode => Object.hash(runtimeType, value);

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -2,15 +2,19 @@ import 'channel.dart';
 import 'socket.dart';
 
 /// Base socket event
-abstract class PhoenixSocketEvent {}
+abstract class PhoenixSocketEvent {
+  const PhoenixSocketEvent();
+}
 
 /// Open event for a [PhoenixSocket].
-class PhoenixSocketOpenEvent extends PhoenixSocketEvent {}
+class PhoenixSocketOpenEvent extends PhoenixSocketEvent {
+  const PhoenixSocketOpenEvent();
+}
 
 /// Close event for a [PhoenixSocket].
 class PhoenixSocketCloseEvent extends PhoenixSocketEvent {
   /// Default constructor for this close event.
-  PhoenixSocketCloseEvent({
+  const PhoenixSocketCloseEvent({
     this.reason,
     this.code,
   });
@@ -40,7 +44,7 @@ class PhoenixSocketCloseEvent extends PhoenixSocketEvent {
 /// Error event for a [PhoenixSocket].
 class PhoenixSocketErrorEvent extends PhoenixSocketEvent {
   /// Default constructor for the error event.
-  PhoenixSocketErrorEvent({
+  const PhoenixSocketErrorEvent({
     this.error,
     this.stacktrace,
   });
@@ -67,7 +71,7 @@ class PhoenixSocketErrorEvent extends PhoenixSocketEvent {
 
 /// Encapsulates constants used in the protocol over [PhoenixChannel].
 class PhoenixChannelEvent {
-  PhoenixChannelEvent._(this.value);
+  const PhoenixChannelEvent._(this.value);
 
   /// A reply event name for a given push ref value.
   factory PhoenixChannelEvent.replyFor(String ref) =>
@@ -77,7 +81,7 @@ class PhoenixChannelEvent {
   ///
   /// This is the event name used when a user of the library sends a message
   /// on a channel.
-  factory PhoenixChannelEvent.custom(name) => PhoenixChannelEvent._(name);
+  const PhoenixChannelEvent.custom(String name) : value = name;
 
   /// Instantiates a PhoenixChannelEvent from
   /// one of the values used in the wire protocol.
@@ -97,6 +101,7 @@ class PhoenixChannelEvent {
         throw ArgumentError.value(value);
     }
   }
+
   static const String __closeEventName = 'phx_close';
   static const String __errorEventName = 'phx_error';
   static const String __joinEventName = 'phx_join';

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -1,4 +1,3 @@
-import 'package:equatable/equatable.dart';
 import 'package:logging/logging.dart';
 
 import 'channel.dart';
@@ -9,7 +8,7 @@ final Logger _logger = Logger('phoenix_socket.message');
 
 /// Class that encapsulate a message being sent or received on a
 /// [PhoenixSocket].
-class Message extends Equatable {
+class Message {
   /// Given a parsed JSON coming from the backend, yield
   /// a [Message] instance.
   factory Message.fromJson(List<dynamic> parts) {
@@ -91,10 +90,24 @@ class Message extends Equatable {
   }
 
   @override
-  List<Object?> get props => [joinRef, ref, topic, event, payload];
+  bool operator ==(Object other) {
+    return other is Message &&
+        other.joinRef == joinRef &&
+        other.ref == ref &&
+        other.topic == topic &&
+        other.event == event &&
+        other.payload == payload;
+  }
 
   @override
-  bool get stringify => true;
+  int get hashCode {
+    return Object.hash(runtimeType, joinRef, ref, topic, event, payload);
+  }
+
+  @override
+  String toString() {
+    return 'Message(joinRef: $joinRef, ref: $ref, topic: $topic, event: $event, payload: $payload)';
+  }
 
   /// Whether the message is a reply message.
   bool get isReply => event.isReply;

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -90,24 +90,21 @@ class Message {
   }
 
   @override
-  bool operator ==(Object other) {
-    return other is Message &&
-        other.joinRef == joinRef &&
-        other.ref == ref &&
-        other.topic == topic &&
-        other.event == event &&
-        other.payload == payload;
-  }
+  bool operator ==(Object other) =>
+      other is Message &&
+      other.joinRef == joinRef &&
+      other.ref == ref &&
+      other.topic == topic &&
+      other.event == event &&
+      other.payload == payload;
 
   @override
-  int get hashCode {
-    return Object.hash(runtimeType, joinRef, ref, topic, event, payload);
-  }
+  int get hashCode =>
+      Object.hash(runtimeType, joinRef, ref, topic, event, payload);
 
   @override
-  String toString() {
-    return 'Message(joinRef: $joinRef, ref: $ref, topic: $topic, event: $event, payload: $payload)';
-  }
+  String toString() =>
+      'Message(joinRef: $joinRef, ref: $ref, topic: $topic, event: $event, payload: $payload)';
 
   /// Whether the message is a reply message.
   bool get isReply => event.isReply;

--- a/lib/src/message_serializer.dart
+++ b/lib/src/message_serializer.dart
@@ -7,24 +7,15 @@ typedef EncoderCallback = String Function(Object? data);
 
 /// Default class to serialize [Message] instances to JSON.
 class MessageSerializer {
-  late DecoderCallback _decoder;
-  late EncoderCallback _encoder;
-
-  MessageSerializer._();
+  final DecoderCallback _decoder;
+  final EncoderCallback _encoder;
 
   /// Default constructor returning the singleton instance of this class.
-  factory MessageSerializer({
-    DecoderCallback? decoder,
-    EncoderCallback? encoder,
-  }) {
-    MessageSerializer instance = _instance ??= MessageSerializer._();
-    instance._decoder = decoder ?? jsonDecode;
-    instance._encoder = encoder ?? jsonEncode;
-
-    return instance;
-  }
-
-  static MessageSerializer? _instance;
+  const MessageSerializer({
+    DecoderCallback decoder = jsonDecode,
+    EncoderCallback encoder = jsonEncode,
+  })  : _decoder = decoder,
+        _encoder = encoder;
 
   /// Yield a [Message] from some raw string arriving from a websocket.
   Message decode(dynamic rawData) {

--- a/lib/src/message_serializer.dart
+++ b/lib/src/message_serializer.dart
@@ -2,18 +2,24 @@ import 'dart:convert';
 
 import 'message.dart';
 
+typedef DecoderCallback = dynamic Function(String rawData);
+typedef EncoderCallback = String Function(Object? data);
+
 /// Default class to serialize [Message] instances to JSON.
 class MessageSerializer {
-  late Function decoder;
-  late Function encoder;
+  late DecoderCallback _decoder;
+  late EncoderCallback _encoder;
 
   MessageSerializer._();
 
   /// Default constructor returning the singleton instance of this class.
-  factory MessageSerializer({decoder, encoder}) {
+  factory MessageSerializer({
+    DecoderCallback? decoder,
+    EncoderCallback? encoder,
+  }) {
     MessageSerializer instance = _instance ??= MessageSerializer._();
-    instance.decoder = decoder ?? jsonDecode;
-    instance.encoder = encoder ?? jsonEncode;
+    instance._decoder = decoder ?? jsonDecode;
+    instance._encoder = encoder ?? jsonEncode;
 
     return instance;
   }
@@ -23,7 +29,7 @@ class MessageSerializer {
   /// Yield a [Message] from some raw string arriving from a websocket.
   Message decode(dynamic rawData) {
     if (rawData is String || rawData is List<int>) {
-      return Message.fromJson(decoder(rawData));
+      return Message.fromJson(_decoder(rawData));
     } else {
       throw ArgumentError('Received a non-string or a non-list of integers');
     }
@@ -31,7 +37,5 @@ class MessageSerializer {
 
   /// Given a [Message], return the raw string that would be sent through
   /// a websocket.
-  String encode(Message message) {
-    return encoder(message.encode());
-  }
+  String encode(Message message) => _encoder(message.encode());
 }

--- a/lib/src/push.dart
+++ b/lib/src/push.dart
@@ -184,10 +184,7 @@ class Push {
   /// Associate a callback to be called if and when a reply with the given
   /// status is received.
   void onReply(String status, ReceiverCallback callback) {
-    _receivers[status] = [
-      ..._receivers[status] ?? [],
-      callback,
-    ];
+    (_receivers[status] ??= []).add(callback);
   }
 
   /// Schedule a timeout to be triggered if no reply occurs

--- a/lib/src/push.dart
+++ b/lib/src/push.dart
@@ -188,7 +188,9 @@ class Push {
     String status,
     void Function(PushResponse) callback,
   ) {
-    _receivers[status]?.add(callback);
+    final receiver = _receivers[status] ??= [];
+    receiver.add(callback);
+    _receivers[status] = receiver;
   }
 
   /// Schedule a timeout to be triggered if no reply occurs

--- a/lib/src/push.dart
+++ b/lib/src/push.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:equatable/equatable.dart';
 import 'package:logging/logging.dart';
 import 'package:quiver/collection.dart';
 
@@ -10,7 +9,7 @@ import 'exceptions.dart';
 import 'message.dart';
 
 /// Encapsulates the response to a [Push].
-class PushResponse extends Equatable {
+class PushResponse {
   /// Builds a PushResponse from a status and response.
   PushResponse({
     this.status,
@@ -56,10 +55,19 @@ class PushResponse extends Equatable {
   bool get isTimeout => status == 'timeout';
 
   @override
-  List<Object?> get props => [status, response];
+  bool operator ==(Object other) {
+    return other is PushResponse &&
+        other.status == status &&
+        other.response == response;
+  }
 
   @override
-  bool get stringify => true;
+  int get hashCode => Object.hash(status, response);
+
+  @override
+  String toString() {
+    return 'PushResponse(status: $status, response: $response)';
+  }
 }
 
 /// Type of function that should return a push payload

--- a/lib/src/push.dart
+++ b/lib/src/push.dart
@@ -7,6 +7,8 @@ import 'events.dart';
 import 'exceptions.dart';
 import 'message.dart';
 
+typedef ReceiverCallback = void Function(PushResponse response);
+
 /// Encapsulates the response to a [Push].
 class PushResponse {
   /// Builds a PushResponse from a status and response.
@@ -88,7 +90,7 @@ class Push {
         _responseCompleter = Completer<PushResponse>();
 
   final Logger _logger;
-  final Map<String, List<void Function(PushResponse)>> _receivers = {};
+  final Map<String, List<ReceiverCallback>> _receivers = {};
 
   /// The event name associated with the pushed message
   final PhoenixChannelEvent? event;
@@ -188,8 +190,10 @@ class Push {
     String status,
     void Function(PushResponse) callback,
   ) {
-    final receiver = (_receivers[status] ??= [])..add(callback);
-    _receivers[status] = receiver;
+    _receivers[status] = [
+      ..._receivers[status] ?? [],
+      callback,
+    ];
   }
 
   /// Schedule a timeout to be triggered if no reply occurs

--- a/lib/src/push.dart
+++ b/lib/src/push.dart
@@ -186,10 +186,7 @@ class Push {
 
   /// Associate a callback to be called if and when a reply with the given
   /// status is received.
-  void onReply(
-    String status,
-    void Function(PushResponse) callback,
-  ) {
+  void onReply(String status, ReceiverCallback callback) {
     _receivers[status] = [
       ..._receivers[status] ?? [],
       callback,

--- a/lib/src/push.dart
+++ b/lib/src/push.dart
@@ -188,8 +188,7 @@ class Push {
     String status,
     void Function(PushResponse) callback,
   ) {
-    final receiver = _receivers[status] ??= [];
-    receiver.add(callback);
+    final receiver = (_receivers[status] ??= [])..add(callback);
     _receivers[status] = receiver;
   }
 

--- a/lib/src/push.dart
+++ b/lib/src/push.dart
@@ -56,19 +56,16 @@ class PushResponse {
   bool get isTimeout => status == 'timeout';
 
   @override
-  bool operator ==(Object other) {
-    return other is PushResponse &&
-        other.status == status &&
-        other.response == response;
-  }
+  bool operator ==(Object other) =>
+      other is PushResponse &&
+      other.status == status &&
+      other.response == response;
 
   @override
   int get hashCode => Object.hash(status, response);
 
   @override
-  String toString() {
-    return 'PushResponse(status: $status, response: $response)';
-  }
+  String toString() => 'PushResponse(status: $status, response: $response)';
 }
 
 /// Type of function that should return a push payload

--- a/lib/src/push.dart
+++ b/lib/src/push.dart
@@ -266,9 +266,7 @@ class Push {
   }
 
   /// Dispose the set of waiters associated with this push.
-  void clearReceivers() {
-    _receivers.clear();
-  }
+  void clearReceivers() => _receivers.clear();
 
   // Remove existing waiters and reset completer
   void cleanUp() {

--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:core';
 import 'dart:math';
 
-import 'package:collection/collection.dart' show IterableExtension;
 import 'package:logging/logging.dart';
+import 'package:phoenix_socket/src/utils/iterable_extensions.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:web_socket_channel/status.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';

--- a/lib/src/socket_options.dart
+++ b/lib/src/socket_options.dart
@@ -1,14 +1,11 @@
-import 'package:meta/meta.dart';
-
 import 'message_serializer.dart';
 
 /// Options for the open Phoenix socket.
 ///
 /// Provided durations are all in milliseconds.
-@immutable
 class PhoenixSocketOptions {
   /// Create a PhoenixSocketOptions
-  PhoenixSocketOptions({
+  const PhoenixSocketOptions({
     /// The duration after which a connection attempt
     /// is considered failed
     Duration? timeout,
@@ -41,7 +38,7 @@ class PhoenixSocketOptions {
     this.dynamicParams,
     MessageSerializer? serializer,
   })  : _timeout = timeout ?? const Duration(seconds: 10),
-        serializer = serializer ?? MessageSerializer(),
+        serializer = serializer ?? const MessageSerializer(),
         _heartbeat = heartbeat ?? const Duration(seconds: 30),
         assert(!(params != null && dynamicParams != null),
             "Can't set both params and dynamicParams");

--- a/lib/src/utils/iterable_extensions.dart
+++ b/lib/src/utils/iterable_extensions.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+//
+// Taken from: https://github.com/dart-lang/collection/blob/master/lib/src/iterable_extensions.dart
+
+extension IterableExtensions<T> on Iterable<T> {
+  /// The first element satisfying [test], or `null` if there are none.
+  T? firstWhereOrNull(bool Function(T) test) {
+    for (final element in this) {
+      if (test(element)) return element;
+    }
+    return null;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,9 +18,9 @@ dependencies:
   web_socket_channel: ^2.0.0
 
 dev_dependencies:
-  build_runner: ^2.4.8
-  lints: ^2.0.0
+  build_runner: ^2.4.9
+  lints: ^3.0.0
   mockito: ^5.4.4
-  test: ^1.11.1
+  test: ^1.25.2
   async: ^2.11.0
   stream_channel: ^2.1.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ environment:
 dependencies:
   collection: ^1.15.0
   logging: ^1.0.0
-  meta: ^1.2.4
   quiver: ^3.0.0
   rxdart: ">=0.26.0 <0.28.0"
   web_socket_channel: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,6 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  equatable: ^2.0.3
   logging: ^1.0.0
   meta: ^1.2.4
   quiver: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ environment:
   sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
-  collection: ^1.15.0
   logging: ^1.0.0
   quiver: ^3.0.0
   rxdart: ">=0.26.0 <0.28.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,16 +8,15 @@ repository: https://www.github.com/matehat/phoenix-socket-dart
 homepage: https://www.github.com/matehat/phoenix-socket-dart
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   collection: ^1.15.0
   equatable: ^2.0.3
   logging: ^1.0.0
   meta: ^1.2.4
-  pedantic: ^1.9.2
   quiver: ^3.0.0
-  rxdart: '>=0.26.0 <0.28.0'
+  rxdart: ">=0.26.0 <0.28.0"
   web_socket_channel: ^2.0.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,11 +8,10 @@ repository: https://www.github.com/matehat/phoenix-socket-dart
 homepage: https://www.github.com/matehat/phoenix-socket-dart
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   logging: ^1.0.0
-  quiver: ^3.0.0
   rxdart: ">=0.26.0 <0.28.0"
   web_socket_channel: ^2.0.0
 

--- a/test/socket_integration_test.dart
+++ b/test/socket_integration_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:pedantic/pedantic.dart';
 import 'package:phoenix_socket/phoenix_socket.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
I'm seeing that this package has a lot of 3rd party dependencies that could be avoided. This is not good as some might conflict in projects that also depend on it (and it might also make the maintenance more cumbersome).
This PR aims to reduce the number of dependencies to its bare minimum.

## Removed dependencies

* `collection` -> implemented `firstWhereOrNull` locally
* `equatable` -> override equality operator and hashCode for the classes that needed it
*  `meta` -> Refactored `PhoenixSocketOptions` so it can be made `const`
* `pedantic` -> Not needed and deprecated
* `quiver` -> Replaced `ListMultimap<String, void Function(PushResponse)>` with a `Map<String, List<void Function(PushResponse)>>`

I've also bumped the version of the dev dependencies and bumped the minimum version of the Dart SDK to `3.0.0` so pattern matching can be used.