### PR TITLE
Await for a successful connection to the websocket before listening to messages

### DIFF
--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -171,7 +171,9 @@ class PhoenixSocket {
   bool get isConnected => _ws != null && _socketState == SocketState.connected;
 
   void _connect(Completer<PhoenixSocket?> completer) async {
-    if (_ws != null) {
+    if (_ws != null &&
+        (_socketState != SocketState.connected ||
+            _socketState != SocketState.connecting)) {
       _logger.warning(
           'Calling connect() on already connected or connecting socket.');
       completer.complete(this);
@@ -514,10 +516,6 @@ class PhoenixSocket {
   void _onSocketData(message) => onSocketDataCallback(message);
 
   void _onSocketError(dynamic error, dynamic stacktrace) {
-    if (_socketState == SocketState.closing ||
-        _socketState == SocketState.closed) {
-      return;
-    }
     final socketError = PhoenixSocketErrorEvent(
       error: error,
       stacktrace: stacktrace,

--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -190,6 +190,12 @@ class PhoenixSocket {
       _ws = _webSocketChannelFactory != null
           ? _webSocketChannelFactory!(_mountPoint)
           : WebSocketChannel.connect(_mountPoint);
+
+      // Wait for the WebSocket to be ready before continuing. In case of a
+      // failure to connect, the future will complete with an error and will be
+      // caught.
+      await _ws!.ready;
+
       _ws!.stream
           .where(_shouldPipeMessage)
           .listen(_onSocketData, cancelOnError: true)


### PR DESCRIPTION
Similar to issues ([issue 1](https://github.com/dart-lang/web_socket_channel/issues/268#issuecomment-1576467535) and [issue 2](https://github.com/dart-lang/web_socket_channel/issues/182#issuecomment-1962903016)) reported in [web_socket_channel](https://github.com/dart-lang/web_socket_channel) package.

When the websocket connection is created and there's an exception thrown at this point we won't be able to catch it, leaving the client in an unrecoverable state (i.e. since the exception is not caught, the websocket artefacts are not properly cleared up). 

`socket.ready` will complete with an error in case something goes wrong during `WebSocketChannel.connect()`. 

It's not an obvious API, but it seems to be the way to go with this package.