### PR TITLE
add timeout to websocket connection and socket heartbeat

### DIFF
--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -164,7 +164,7 @@ class PhoenixSocket {
   String get endpoint => _endpoint;
 
   /// The [Uri] containing all the parameters and options for the
-  /// remote connection to occue.
+  /// remote connection to occur.
   Uri get mountPoint => _mountPoint;
 
   /// Whether the underlying socket is connected of not.
@@ -222,6 +222,17 @@ class PhoenixSocket {
       } else {
         throw PhoenixException();
       }
+    } on TimeoutException catch (err, stackTrace) {
+      _logger.severe(
+          'Timed out waiting for WebSocket to be ready', err, stackTrace);
+      _closeSink();
+      _ws = null;
+      _socketState = SocketState.closed;
+      // Calling this method will trigger a reconnect
+      // making _shouldReconnect = false as we are manually calling _delayedReconnect()
+      _shouldReconnect = false;
+      _onSocketError(err, stackTrace);
+      completer.complete(_delayedReconnect());
     } catch (err, stackTrace) {
       _logger.severe('Raised Exception', err, stackTrace);
 

--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -282,6 +282,7 @@ class PhoenixSocket {
 
     _disposed = true;
     _ws?.sink.close();
+    _cancelHeartbeat();
 
     for (final sub in _subscriptions) {
       sub.cancel();

--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -235,7 +235,7 @@ class PhoenixSocket {
       completer.complete(_delayedReconnect());
     } catch (err, stackTrace) {
       _logger.severe('Raised Exception', err, stackTrace);
-
+      _closeSink();
       _ws = null;
       _socketState = SocketState.closed;
 
@@ -573,6 +573,7 @@ class PhoenixSocket {
       code: _ws?.closeCode,
     );
     final exc = PhoenixException(socketClosed: ev);
+    _closeSink();
     _ws = null;
 
     if (!_stateStreamController.isClosed) {

--- a/lib/src/socket_options.dart
+++ b/lib/src/socket_options.dart
@@ -13,6 +13,10 @@ class PhoenixSocketOptions {
     /// The interval between heartbeat roundtrips
     Duration? heartbeat,
 
+    /// The duration after which a heartbeat request
+    /// is considered timed out
+    Duration? heartbeatTimeout,
+
     /// The list of delays between reconnection attempts.
     ///
     /// The last duration will be repeated until it works.
@@ -40,6 +44,7 @@ class PhoenixSocketOptions {
   })  : _timeout = timeout ?? const Duration(seconds: 10),
         serializer = serializer ?? const MessageSerializer(),
         _heartbeat = heartbeat ?? const Duration(seconds: 30),
+        _heartbeatTimeout = heartbeatTimeout ?? const Duration(seconds: 10),
         assert(!(params != null && dynamicParams != null),
             "Can't set both params and dynamicParams");
 
@@ -49,12 +54,18 @@ class PhoenixSocketOptions {
 
   final Duration _timeout;
   final Duration _heartbeat;
+  final Duration _heartbeatTimeout;
 
   /// Duration after which a request is assumed to have timed out.
   Duration get timeout => _timeout;
 
   /// Duration between heartbeats
   Duration get heartbeat => _heartbeat;
+
+  /// Duration after which a heartbeat request is considered timed out.
+  /// If the server does not respond to a heartbeat request within this
+  /// duration, the connection is considered lost.
+  Duration get heartbeatTimeout => _heartbeatTimeout;
 
   /// Optional list of Duration between reconnect attempts
   final List<Duration> reconnectDelays;


### PR DESCRIPTION
Add timeout to websocket connection and send socket heartbeat, else in case of no internet, ```await _ws!.ready``` is stuck indefinitely. This causes the socket not to try reconnecting while the internet is not present.

A similar case would happen in the previous versions of the library when ```await _ws!.ready``` was not added. It gets stuck indefinitely when sending a socket heartbeat. 