### PR TITLE
chore: bump `rxdart` version to ^0.28.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.0.0
-  rxdart: ^0.27.0
+  rxdart: ^0.28.0
   web_socket_channel: ^3.0.1
 
 dev_dependencies:


### PR DESCRIPTION
The current version is not compatible with `custom_lints` version 0.7.0 (requires `rxdart: ^0.28.0`)