### PR TITLE
Add binary message decoding/encoding support for message and optional payload decoder.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
         ports:
           - 4001:4001
           - 4002:4002
-        
+
       proxy:
         image: ghcr.io/shopify/toxiproxy
         ports:
@@ -26,12 +26,11 @@ jobs:
           - 4004:4004
 
     steps:
-
       - name: Setup Dart
         uses: dart-lang/setup-dart@v1
         with:
           architecture: x64
-          sdk: "3.1.2"
+          sdk: "3.7.2"
 
       - name: Fetch sources
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.7.6.]
+
+- Change referenced rxdart version ^0.27.0
+
 ## [0.7.5.]
 
 - Upgrade web_socket_channel to 3.0.1

--- a/lib/src/message_serializer.dart
+++ b/lib/src/message_serializer.dart
@@ -1,6 +1,9 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
-import 'message.dart';
+import 'package:msgpack_dart/msgpack_dart.dart';
+import 'package:phoenix_socket/phoenix_socket.dart';
+import 'package:phoenix_socket/src/utils/serializer.dart';
 
 typedef DecoderCallback = dynamic Function(String rawData);
 typedef EncoderCallback = String Function(Object? data);
@@ -9,18 +12,29 @@ typedef EncoderCallback = String Function(Object? data);
 class MessageSerializer {
   final DecoderCallback _decoder;
   final EncoderCallback _encoder;
+  final bool useMessagePack;
 
   /// Default constructor returning the singleton instance of this class.
   const MessageSerializer({
     DecoderCallback decoder = jsonDecode,
     EncoderCallback encoder = jsonEncode,
+    this.useMessagePack = true,
   })  : _decoder = decoder,
         _encoder = encoder;
 
   /// Yield a [Message] from some raw string arriving from a websocket.
   Message decode(dynamic rawData) {
-    if (rawData is String || rawData is List<int>) {
+    if (rawData is String) {
       return Message.fromJson(_decoder(rawData));
+    } else if (rawData is Uint8List) {
+      final rawMap = BinaryDecoder.binaryDecode(rawData);
+      return Message(
+        joinRef: rawMap['join_ref'],
+        ref: rawMap['ref'],
+        topic: rawMap['topic'],
+        event: PhoenixChannelEvent.custom(rawMap['event']),
+        payload: _getPayload(rawMap['payload']),
+      );
     } else {
       throw ArgumentError('Received a non-string or a non-list of integers');
     }
@@ -29,4 +43,37 @@ class MessageSerializer {
   /// Given a [Message], return the raw string that would be sent through
   /// a websocket.
   String encode(Message message) => _encoder(message.encode());
+
+  Map<String, dynamic>? _getPayload(payLoad) {
+    if (useMessagePack && payLoad is Uint8List) {
+      final deserializedPayload = deserialize(payLoad);
+      if (deserializedPayload is Map) {
+        return deepConvertToStringDynamic(deserializedPayload);
+      } else {
+        return {'data': deserializedPayload};
+      }
+    } else {
+      return payLoad;
+    }
+  }
+}
+
+Map<String, dynamic> deepConvertToStringDynamic(Map<dynamic, dynamic> input) {
+  return input.map((key, value) {
+    if (value is Map) {
+      return MapEntry(key.toString(), deepConvertToStringDynamic(value));
+    } else if (value is List) {
+      return MapEntry(
+          key.toString(),
+          value.map((element) {
+            if (element is Map) {
+              return deepConvertToStringDynamic(element);
+            } else {
+              return element;
+            }
+          }).toList());
+    } else {
+      return MapEntry(key.toString(), value);
+    }
+  });
 }

--- a/lib/src/socket.dart
+++ b/lib/src/socket.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:core';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:logging/logging.dart';
 import 'package:phoenix_socket/src/utils/iterable_extensions.dart';
@@ -86,7 +87,7 @@ class PhoenixSocket {
 
   final BehaviorSubject<PhoenixSocketEvent> _stateStreamController =
       BehaviorSubject();
-  final StreamController<String> _receiveStreamController =
+  final StreamController<dynamic> _receiveStreamController =
       StreamController.broadcast();
   final String _endpoint;
   final StreamController<Message> _topicMessages = StreamController();
@@ -408,7 +409,7 @@ class PhoenixSocket {
   ///
   /// Used to define a custom message type for proper data decoding
   onSocketDataCallback(message) {
-    if (message is String) {
+    if (message is String || message is Uint8List) {
       if (!_receiveStreamController.isClosed) {
         _receiveStreamController.add(message);
       }

--- a/lib/src/socket_options.dart
+++ b/lib/src/socket_options.dart
@@ -5,7 +5,7 @@ import 'message_serializer.dart';
 /// Provided durations are all in milliseconds.
 class PhoenixSocketOptions {
   /// Create a PhoenixSocketOptions
-  const PhoenixSocketOptions({
+  PhoenixSocketOptions({
     /// The duration after which a connection attempt
     /// is considered failed
     Duration? timeout,
@@ -16,6 +16,9 @@ class PhoenixSocketOptions {
     /// The duration after which a heartbeat request
     /// is considered timed out
     Duration? heartbeatTimeout,
+
+    /// Whether to use MessagePack for serialization.
+    this.useMessagePack = false,
 
     /// The list of delays between reconnection attempts.
     ///
@@ -42,7 +45,8 @@ class PhoenixSocketOptions {
     this.dynamicParams,
     MessageSerializer? serializer,
   })  : _timeout = timeout ?? const Duration(seconds: 10),
-        serializer = serializer ?? const MessageSerializer(),
+        serializer =
+            serializer ?? MessageSerializer(useMessagePack: useMessagePack),
         _heartbeat = heartbeat ?? const Duration(seconds: 30),
         _heartbeatTimeout = heartbeatTimeout ?? const Duration(seconds: 10),
         assert(!(params != null && dynamicParams != null),
@@ -73,6 +77,9 @@ class PhoenixSocketOptions {
   /// Parameters sent to your Phoenix backend on connection.
   /// Use [dynamicParams] if your params are dynamic.
   final Map<String, String>? params;
+
+  /// Whether to use MessagePack for serialization.
+  final bool useMessagePack;
 
   /// Will be called to get fresh params before each connection attempt.
   final Future<Map<String, String>> Function()? dynamicParams;

--- a/lib/src/utils/serializer.dart
+++ b/lib/src/utils/serializer.dart
@@ -1,0 +1,113 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+class BinaryDecoder {
+  static const headerLength = 1;
+  static const metaLength = 4;
+
+  static const Map<String, int> kinds = {
+    'push': 0,
+    'reply': 1,
+    'broadcast': 2,
+  };
+
+  static const Map<String, String> channelEvents = {
+    'reply': 'phx_reply',
+  };
+
+  static Map<String, dynamic> binaryDecode(Uint8List buffer) {
+    ByteData view = ByteData.view(buffer.buffer);
+    int kind = view.getUint8(0);
+
+    switch (kind) {
+      case 0: // push
+        return decodePush(buffer, view);
+      case 1: // reply
+        return decodeReply(buffer, view);
+      case 2: // broadcast
+        return decodeBroadcast(buffer, view);
+      default:
+        throw Exception('Unknown message kind: $kind');
+    }
+  }
+
+  static Map<String, dynamic> decodePush(Uint8List buffer, ByteData view) {
+    int joinRefSize = view.getUint8(1);
+    int topicSize = view.getUint8(2);
+    int eventSize = view.getUint8(3);
+    int offset = headerLength + metaLength - 1; // pushes have no ref
+
+    String joinRef = utf8.decode(buffer.sublist(offset, offset + joinRefSize));
+    offset += joinRefSize;
+
+    String topic = utf8.decode(buffer.sublist(offset, offset + topicSize));
+    offset += topicSize;
+
+    String event = utf8.decode(buffer.sublist(offset, offset + eventSize));
+    offset += eventSize;
+
+    Uint8List data = buffer.sublist(offset);
+
+    return {
+      'join_ref': joinRef,
+      'ref': null,
+      'topic': topic,
+      'event': event,
+      'payload': data
+    };
+  }
+
+  static Map<String, dynamic> decodeReply(Uint8List buffer, ByteData view) {
+    int joinRefSize = view.getUint8(1);
+    int refSize = view.getUint8(2);
+    int topicSize = view.getUint8(3);
+    int eventSize = view.getUint8(4);
+    int offset = headerLength + metaLength;
+
+    String joinRef = utf8.decode(buffer.sublist(offset, offset + joinRefSize));
+    offset += joinRefSize;
+
+    String ref = utf8.decode(buffer.sublist(offset, offset + refSize));
+    offset += refSize;
+
+    String topic = utf8.decode(buffer.sublist(offset, offset + topicSize));
+    offset += topicSize;
+
+    String event = utf8.decode(buffer.sublist(offset, offset + eventSize));
+    offset += eventSize;
+
+    Uint8List data = buffer.sublist(offset);
+
+    Map<String, dynamic> payload = {'status': event, 'response': data};
+
+    return {
+      'join_ref': joinRef,
+      'ref': ref,
+      'topic': topic,
+      'event': channelEvents['reply'],
+      'payload': payload
+    };
+  }
+
+  static Map<String, dynamic> decodeBroadcast(Uint8List buffer, ByteData view) {
+    int topicSize = view.getUint8(1);
+    int eventSize = view.getUint8(2);
+    int offset = headerLength + 2;
+
+    String topic = utf8.decode(buffer.sublist(offset, offset + topicSize));
+    offset += topicSize;
+
+    String event = utf8.decode(buffer.sublist(offset, offset + eventSize));
+    offset += eventSize;
+
+    Uint8List data = buffer.sublist(offset);
+
+    return {
+      'join_ref': null,
+      'ref': null,
+      'topic': topic,
+      'event': event,
+      'payload': data
+    };
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   logging: ^1.0.0
-  rxdart: ^0.27.0
+  rxdart: ^0.28.0
   web_socket_channel: ^3.0.1
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   PhoenixSocket provides a feature-complete implementation
   of Phoenix Sockets, using a single API based on StreamChannels
   compatible with any deployment of Flutter.
-version: 0.7.5
+version: 0.7.6
 repository: https://www.github.com/matehat/phoenix-socket-dart
 homepage: https://www.github.com/matehat/phoenix-socket-dart
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   logging: ^1.0.0
   rxdart: ^0.28.0
   web_socket_channel: ^3.0.1
+  msgpack_dart: ^1.0.1
 
 dev_dependencies:
   build_runner: ^2.4.9


### PR DESCRIPTION
## Add binary message decoding/encoding support for message and optional payload decoder.

### Use case:

- There are cases where the server sends the data payload as binary data. The library only had support for accepting the data as String with payload as Map<String, dynamic>. Hence this PR adds support for parsing and handling the data when received as `UInt8List` instead of `String`.
This adds the binary decoding logic based on the standard phoenix message protocol.
More reference here: https://github.com/phoenixframework/phoenix/blob/main/assets/js/phoenix/serializer.js#L56

- This also allows passing an optional payload decoder to the `MessageSerializer` class. That would help in the case where payload is encoded using an encoder service like [msgpack](https://msgpack.org/).

