### PR TITLE
perf: skip deep key conversion for already string-keyed decoded payloads

### DIFF
--- a/lib/src/message_serializer.dart
+++ b/lib/src/message_serializer.dart
@@ -72,7 +72,14 @@ class MessageSerializer {
   dynamic _getPayload(dynamic payLoad) {
     if (_payloadDecoder != null && payLoad is Uint8List) {
       final deserializedPayload = _payloadDecoder!(payLoad);
-      if (deserializedPayload is Map) {
+      if (deserializedPayload is Map<String, dynamic>) {
+        // Already string-keyed at every level (e.g. jsonDecode output) — the
+        // deep rebuild below would recursively copy the entire payload tree
+        // for nothing. On multi-MB payloads that rebuild can dominate
+        // main-thread time in consuming apps.
+        return deserializedPayload;
+      } else if (deserializedPayload is Map) {
+        // Dynamic-keyed maps (e.g. msgpack output) genuinely need conversion.
         return MapUtils.deepConvertToStringDynamic(deserializedPayload);
       } else if (deserializedPayload is Uint8List) {
         return deserializedPayload;

--- a/test/message_serializer_test.dart
+++ b/test/message_serializer_test.dart
@@ -224,6 +224,53 @@ void main() {
         expect(decoded.payload?['list'][0]['item'], equals(1));
         expect(decoded.payload?['list'][1]['item'], equals(2));
       });
+
+      test('returns string-keyed decoder output without rebuilding it', () {
+        final original = <String, dynamic>{
+          'nested': <String, dynamic>{'data': 42},
+        };
+        final serializer = MessageSerializer(
+          payloadDecoder: (payload) => original,
+        );
+
+        final List<int> message = [
+          2, // broadcast type
+          3, // topic length
+          5, // event length
+          ...utf8.encode('top'),
+          ...utf8.encode('event'),
+          1, // payload
+        ];
+
+        final decoded = serializer.decode(Uint8List.fromList(message));
+
+        // Already Map<String, dynamic> at every level: the deep key
+        // conversion is skipped, so the exact instance passes through.
+        expect(identical(decoded.payload, original), isTrue);
+      });
+
+      test('still converts dynamic-keyed decoder output', () {
+        final serializer = MessageSerializer(
+          payloadDecoder: (payload) => <dynamic, dynamic>{
+            'nested': <dynamic, dynamic>{'data': 42},
+          },
+        );
+
+        final List<int> message = [
+          2, // broadcast type
+          3, // topic length
+          5, // event length
+          ...utf8.encode('top'),
+          ...utf8.encode('event'),
+          1, // payload
+        ];
+
+        final decoded = serializer.decode(Uint8List.fromList(message));
+
+        expect(decoded.payload, isA<Map<String, dynamic>>());
+        expect(decoded.payload?['nested'], isA<Map<String, dynamic>>());
+        expect(decoded.payload?['nested']['data'], equals(42));
+      });
     });
   });
 }


### PR DESCRIPTION
## What

`MessageSerializer._getPayload` runs `MapUtils.deepConvertToStringDynamic` on every `Map` returned by a custom `payloadDecoder`, recursively rebuilding the entire payload tree. When the decoder already yields `Map<String, dynamic>` at every level — which `jsonDecode` guarantees — the rebuild produces an identical structure at full-tree-copy cost.

This PR returns string-keyed maps as-is and keeps the conversion for dynamic-keyed maps (e.g. msgpack decoder output), whose consumers genuinely rely on it.

## Why

We stream large binary payloads (multi-MB JSON event frames) through a `payloadDecoder`. CPU profiling showed `deepConvertToStringDynamic` at ~80% of main-thread time during a load window — all of it spent rebuilding maps that were already in the target shape:

| | before | after |
|---|---|---|
| `deepConvertToStringDynamic` (3.1s profile window) | 2.52s (82%) | not present |

## Behavior

- `Map<String, dynamic>` decoder output: passed through by identity (new test asserts `identical`).
- Any other `Map`: converted exactly as before (existing behavior, new regression test).
- Non-map / `Uint8List` branches: untouched.

All existing serializer tests pass; two tests added.